### PR TITLE
Define BitString on keys protocol 

### DIFF
--- a/lib/protocols/keys.ex
+++ b/lib/protocols/keys.ex
@@ -18,3 +18,6 @@ defimpl Exleveldb.Keys, for: List do
   def to_key(charlist), do: List.to_string(charlist)
 end
 
+defimpl Exleveldb.Keys, for: BitString do
+  def to_key(string), do: string
+end


### PR DESCRIPTION
since it is required on any function that is using a key as an argument. Now all tests are passing